### PR TITLE
Fix gh-pages deployment

### DIFF
--- a/.github/workflows/jb-gh-pages.yml
+++ b/.github/workflows/jb-gh-pages.yml
@@ -9,7 +9,7 @@ jobs:
   docs:
     strategy:
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.9']
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
@@ -21,10 +21,10 @@ jobs:
       - name: install tox
         run: python -m pip install --upgrade tox virtualenv setuptools pip
       - name: run docs
-        run: tox -epy38
+        run: tox -epy39
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/html/
-          publish_branch: main  # deploying branch
+          publish_branch: docs  # deploying branch

--- a/source/README.md
+++ b/source/README.md
@@ -1,3 +1,1 @@
 # utils-rh
-
-change 2


### PR DESCRIPTION
This commit changes the tox python version in gh workflows to match the
one in tox.ini, as well as the source for the html page.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>